### PR TITLE
Truncate more text to avoid invalid_blocks

### DIFF
--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -211,3 +211,9 @@ def test_slack_api_call_error():
 
     assert not resp['ok']
     assert resp['error'] == 'ValueError: error msg'
+
+
+def test_truncate_blocks_text():
+    blocks = [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'A' * 5000}}]
+    truncated = slack.truncate_blocks_text(blocks)
+    assert truncated == [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'A' * 3000}}]


### PR DESCRIPTION
This attempts to do a better job of truncating text, at least in the most egregious cases. I especially want to make sure we don't get `invalid_blocks` errors when starting the thread, so that later messages to the thread don't get `message_not_found` errors.