### PR TITLE
Add filter for slack webhook event stream

### DIFF
--- a/sticht/slack.py
+++ b/sticht/slack.py
@@ -84,8 +84,16 @@ def parse_webhook_event_json(line):
 
 
 def is_relevant_event(event):
-    # TODO: Implement filtering
-    return True
+    """
+    Filter useful events from the slack webhook stream.
+
+    The event stream might contain mixed Slack API data (Events and Blocks)
+    see more https://api.slack.com/events-api
+    """
+    if event and 'type' in event:
+        if event['type'] == 'block_actions':
+            return True
+    return False
 
 
 async def get_slack_events():

--- a/tests/test_slack.py
+++ b/tests/test_slack.py
@@ -102,6 +102,34 @@ REAL_ROLLBACK_PRESS = {
     ],
 }  # noqa E501
 
+MIXED_EVENTS_STREAM = [
+    {
+        'type': 'block_actions',
+        'event_id': '123',
+        'user': {
+            'id': 'XXXXXXXXX',
+            'username': 'XXX',
+            'name': 'XXX',
+            'team_id': '1234',
+        },
+        'token': 'xxxx',
+    },
+    {
+        'type': 'event_callback',
+        'token': 'xxxx',
+        'team_id': 'xxxx',
+        'event_id': '789',
+        'event': {
+            'type': 'link_shared',
+            'user': 'ASLKDJA',
+            'channel': 'AKDJL',
+            'message_ts': '1597270855.028300',
+            'thread_ts': '1597096154.261800',
+            'event_ts': '1597270856.073628',
+        },
+    },
+]  # noqa E501
+
 
 class DummySlackDeploymentProcess(slack.SlackDeploymentProcess):
     """A minimum-viable SlackDeploymentProcess subclass."""
@@ -217,3 +245,10 @@ def test_truncate_blocks_text():
     blocks = [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'A' * 5000}}]
     truncated = slack.truncate_blocks_text(blocks)
     assert truncated == [{'type': 'section', 'text': {'type': 'mrkdwn', 'text': 'A' * 3000}}]
+
+
+def test_is_relevant_event():
+    # First event is useful
+    assert slack.is_relevant_event(MIXED_EVENTS_STREAM[0]) is True
+    # 2nd event should be ignored
+    assert slack.is_relevant_event(MIXED_EVENTS_STREAM[1]) is False


### PR DESCRIPTION
Our internal webhook stream has several event types, that are causing crashes.

Testing is light; not sure how to integrate test this but I'm reasonably confident this a defensive code approach.