### PR TITLE
PAASTA-17227 - Adding KeyError fix for SLO Watchers

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -19,4 +19,4 @@ mypy==0.720
 pre-commit>=1.0.0
 pytest
 slackclient==1.2.1
-urllib3==1.24.3
+urllib3==1.26.2

--- a/sticht/slo.py
+++ b/sticht/slo.py
@@ -114,8 +114,9 @@ class SLODemultiplexer:
 
     def process_datapoint(self, props, datapoint, timestamp) -> None:
         slo_label = props['dimensions']['sf_metric'].rsplit('.', 1)[0]
-        watcher = self.slo_watchers_by_label[slo_label]
-        watcher.process_datapoint(props, datapoint, timestamp)
+        if not slo_label.startswith('_SF_COMP_'):
+            watcher = self.slo_watchers_by_label[slo_label]
+            watcher.process_datapoint(props, datapoint, timestamp)
 
 
 class SLOWatcher:

--- a/tests/test_slo.py
+++ b/tests/test_slo.py
@@ -132,6 +132,17 @@ def test_SLODemultiplexer():
     assert demux.slo_watchers_by_label['slo_3'].process_datapoint.call_count == 1
     demux.slo_watchers_by_label['slo_3'].process_datapoint.reset_mock()
 
+    keyErrorRaised = False
+
+    try:
+        demux.process_datapoint(
+            props={'dimensions': {'sf_metric': '_SF_COMP_E123ABC'}}, datapoint=good, timestamp=0.0,
+        )
+    except KeyError:
+        keyErrorRaised = True
+
+    assert keyErrorRaised is False
+
     assert individual_slo_callback.call_count == 0
 
 

--- a/tests/test_slo.py
+++ b/tests/test_slo.py
@@ -132,16 +132,10 @@ def test_SLODemultiplexer():
     assert demux.slo_watchers_by_label['slo_3'].process_datapoint.call_count == 1
     demux.slo_watchers_by_label['slo_3'].process_datapoint.reset_mock()
 
-    keyErrorRaised = False
-
-    try:
-        demux.process_datapoint(
-            props={'dimensions': {'sf_metric': '_SF_COMP_E123ABC'}}, datapoint=good, timestamp=0.0,
-        )
-    except KeyError:
-        keyErrorRaised = True
-
-    assert keyErrorRaised is False
+    # SignalFx generated metric ("_SF_COMP*") is discarded
+    demux.process_datapoint(
+        props={'dimensions': {'sf_metric': '_SF_COMP_E123ABC'}}, datapoint=good, timestamp=0.0,
+    )
 
     assert individual_slo_callback.call_count == 0
 


### PR DESCRIPTION
### Description
Adding fix to KeyErrors for SLO Watchers threads in Sticht.  Many users have been experiencing KeyErrors whenever they deploy their services. This error occurs whenever we try to call an SLO Watcher with a non existing SLO label.

SLO labels are retrieved through the SignalFx stream. After some investigation, it appears that SignalFx also generates its own SLO label which looks like "_SF_COMP_". As we did not create this SLO label, no SLO watcher with that label actually exists. This results into a KeyError exception being raised.

In other words, the first item in the list of SLO labels that we receive from the SignalFx stream is just arbitrary info that SignalFx generates and therefore can be ignored.


### Tests
`make test` - PASSED