### PR TITLE
Add base MetricWatcher class

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -1,9 +1,10 @@
 import abc
-from typing import Any
 from typing import List
 from typing import Optional
 from typing import Tuple
 
+from sticht.rollbacks.metrics import MetricWatcher
+from sticht.rollbacks.metrics import watch_metrics_for_service
 from sticht.rollbacks.slo import SLOWatcher
 from sticht.rollbacks.slo import watch_slos_for_service
 from sticht.slack import Emoji
@@ -13,7 +14,7 @@ from sticht.slack import SlackDeploymentProcess
 class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
     def __init__(self) -> None:
         self.slo_watchers: Optional[List[SLOWatcher]] = None
-        self.metric_watchers: Optional[List[Any]] = None
+        self.metric_watchers: Optional[List[MetricWatcher]] = None
         # normally you'd expect that this be called first thing in __init__,
         # but the way this class is constructed means that one of the methods called
         # by our superclass's constructor will throw when it tries to access the watcher
@@ -171,7 +172,7 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
         )
 
     def start_metric_watcher_threads(self, service: str, soa_dir: str) -> None:
-        raise NotImplementedError()
+        _, self.metric_watchers = watch_metrics_for_service(service=service, soa_dir=soa_dir)
 
     @abc.abstractmethod
     def get_signalfx_api_token(self) -> str:

--- a/sticht/rollbacks/metrics.py
+++ b/sticht/rollbacks/metrics.py
@@ -1,0 +1,50 @@
+import threading
+from typing import Any
+from typing import Callable
+from typing import List
+from typing import Optional
+from typing import Tuple
+
+
+class MetricWatcher:
+    """
+    Base class for the different classes of metric sources that will be used
+    for automatic rollbacks
+    """
+    # TODO: figure out contents of this class in a more thought-out way
+
+    def __init__(self, label: str, on_failure_callback: Callable[['MetricWatcher'], None]) -> None:
+        # is the metric in question currently failing? (None == unknown)
+        self.failing: Optional[bool] = None
+        # was the metric failing *before* the deployment began? (None == unknown)
+        self.previously_failing: Optional[bool] = None
+        # how should we refer to this metric in Slack?
+        self.label = label
+        # how do we notify that a metric is newly failing?
+        self.on_failure_callback = on_failure_callback
+
+    def query(self) -> None:
+        """
+        Part of the public interface for a MetricWatcher.
+        Should send the configured query to the relevant metric source and
+        compare it against the configured thresholds (and, if failing, invoke
+        the callback held by this class)
+        """
+        raise NotImplementedError()
+
+    def process_result(self, result: Any) -> None:
+        """
+        Part of the public interface for a MetricWatcher.
+        Will be called by query() with some data which should be compared
+        against the configured thresholds (and, if failing, invoke the callback
+        held by this class)
+        """
+        raise NotImplementedError()
+
+
+def watch_metrics_for_service(service: str, soa_dir: str) -> Tuple[List[threading.Thread], List[MetricWatcher]]:
+    threads: List[threading.Thread] = []
+    watchers: List[MetricWatcher] = []
+
+    # TODO: actually implement :)
+    return threads, watchers

--- a/tox.ini
+++ b/tox.ini
@@ -24,7 +24,7 @@ passenv = HOME SSH_AUTH_SOCK USER
 commands =
     coverage erase
     coverage run -m pytest {posargs:tests}
-    coverage report --fail-under 55
+    coverage report --fail-under 54
     pre-commit install -f --install-hooks
     pre-commit run --all-files
 


### PR DESCRIPTION
This defines the interface that our actual metric source query classes
will adhere to.