### PR TITLE
Move MetricWatcher to prevent circular import in the future

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -3,10 +3,10 @@ from typing import List
 from typing import Optional
 from typing import Tuple
 
-from sticht.rollbacks.metrics import MetricWatcher
 from sticht.rollbacks.metrics import watch_metrics_for_service
 from sticht.rollbacks.slo import SLOWatcher
 from sticht.rollbacks.slo import watch_slos_for_service
+from sticht.rollbacks.types import MetricWatcher
 from sticht.slack import Emoji
 from sticht.slack import SlackDeploymentProcess
 

--- a/sticht/rollbacks/metrics.py
+++ b/sticht/rollbacks/metrics.py
@@ -1,45 +1,8 @@
 import threading
-from typing import Any
-from typing import Callable
 from typing import List
-from typing import Optional
 from typing import Tuple
 
-
-class MetricWatcher:
-    """
-    Base class for the different classes of metric sources that will be used
-    for automatic rollbacks
-    """
-    # TODO: figure out contents of this class in a more thought-out way
-
-    def __init__(self, label: str, on_failure_callback: Callable[['MetricWatcher'], None]) -> None:
-        # is the metric in question currently failing? (None == unknown)
-        self.failing: Optional[bool] = None
-        # was the metric failing *before* the deployment began? (None == unknown)
-        self.previously_failing: Optional[bool] = None
-        # how should we refer to this metric in Slack?
-        self.label = label
-        # how do we notify that a metric is newly failing?
-        self.on_failure_callback = on_failure_callback
-
-    def query(self) -> None:
-        """
-        Part of the public interface for a MetricWatcher.
-        Should send the configured query to the relevant metric source and
-        compare it against the configured thresholds (and, if failing, invoke
-        the callback held by this class)
-        """
-        raise NotImplementedError()
-
-    def process_result(self, result: Any) -> None:
-        """
-        Part of the public interface for a MetricWatcher.
-        Will be called by query() with some data which should be compared
-        against the configured thresholds (and, if failing, invoke the callback
-        held by this class)
-        """
-        raise NotImplementedError()
+from sticht.rollbacks.types import MetricWatcher
 
 
 def watch_metrics_for_service(service: str, soa_dir: str) -> Tuple[List[threading.Thread], List[MetricWatcher]]:

--- a/sticht/rollbacks/sources/splunk.py
+++ b/sticht/rollbacks/sources/splunk.py
@@ -9,7 +9,7 @@ from typing import Optional
 import splunklib.client
 import splunklib.results
 
-from sticht.rollbacks.metrics import MetricWatcher
+from sticht.rollbacks.types import MetricWatcher
 from sticht.rollbacks.types import SplunkAuth
 
 

--- a/sticht/rollbacks/types.py
+++ b/sticht/rollbacks/types.py
@@ -1,4 +1,43 @@
+from typing import Any
+from typing import Callable
 from typing import NamedTuple
+from typing import Optional
+
+
+class MetricWatcher:
+    """
+    Base class for the different classes of metric sources that will be used
+    for automatic rollbacks
+    """
+    # TODO: figure out contents of this class in a more thought-out way
+
+    def __init__(self, label: str, on_failure_callback: Callable[['MetricWatcher'], None]) -> None:
+        # is the metric in question currently failing? (None == unknown)
+        self.failing: Optional[bool] = None
+        # was the metric failing *before* the deployment began? (None == unknown)
+        self.previously_failing: Optional[bool] = None
+        # how should we refer to this metric in Slack?
+        self.label = label
+        # how do we notify that a metric is newly failing?
+        self.on_failure_callback = on_failure_callback
+
+    def query(self) -> None:
+        """
+        Part of the public interface for a MetricWatcher.
+        Should send the configured query to the relevant metric source and
+        compare it against the configured thresholds (and, if failing, invoke
+        the callback held by this class)
+        """
+        raise NotImplementedError()
+
+    def process_result(self, result: Any) -> None:
+        """
+        Part of the public interface for a MetricWatcher.
+        Will be called by query() with some data which should be compared
+        against the configured thresholds (and, if failing, invoke the callback
+        held by this class)
+        """
+        raise NotImplementedError()
 
 
 class SplunkAuth(NamedTuple):


### PR DESCRIPTION
In an upcoming commit, I'll be adding creating SplunkMetricWatchers in a
RollbackDeploymentProcess, but the way things are currently laid out
means that SplunkMetricWatcher will need to import MetricWatcher from
metrics.py - but metrics.py would also need to import from the file that
holds the SplunkMetricWatcher definition, leading to a circular import