### PR TITLE
Actually create MetricWatchers

### DIFF
--- a/sticht/exceptions.py
+++ b/sticht/exceptions.py
@@ -1,0 +1,2 @@
+class MissingConfigException(Exception):
+    pass

--- a/sticht/rollbacks/metrics.py
+++ b/sticht/rollbacks/metrics.py
@@ -1,13 +1,80 @@
+import logging
 import threading
+from typing import Any
+from typing import Callable
+from typing import Dict
 from typing import List
+from typing import Optional
 from typing import Tuple
 
+import yaml
+
+from sticht.exceptions import MissingConfigException
+from sticht.rollbacks.soaconfigs import get_cluster_from_soaconfigs_filename
+from sticht.rollbacks.soaconfigs import get_rollback_files_from_soaconfigs
+from sticht.rollbacks.sources.splunk import create_splunk_metricwatchers
 from sticht.rollbacks.types import MetricWatcher
+from sticht.rollbacks.types import SplunkAuth
+
+log = logging.getLogger(__name__)
 
 
-def watch_metrics_for_service(service: str, soa_dir: str) -> Tuple[List[threading.Thread], List[MetricWatcher]]:
+def _get_metric_configs_for_service_by_cluster(
+    service: str,
+    soa_dir: str,
+) -> Dict[str, Dict[str, Any]]:  # TODO: add type for rollback file config
+    configs = {}
+    for filename in get_rollback_files_from_soaconfigs(soa_dir, service=service):
+        with open(filename, 'r') as file:
+            configs[get_cluster_from_soaconfigs_filename(filename)] = yaml.safe_load(file)
+    return configs
+
+
+def watch_metrics_for_service(
+    service: str,
+    soa_dir: str,
+    on_failure_callback: Callable[[str, Optional[bool]], None],
+    on_failure_trigger_callback: Callable[[bool], None],
+    splunk_auth_callback: Optional[Callable[[], SplunkAuth]] = None,
+) -> Tuple[List[threading.Thread], List[MetricWatcher]]:
     threads: List[threading.Thread] = []
     watchers: List[MetricWatcher] = []
 
-    # TODO: actually implement :)
+    failing = False
+
+    def callback_wrapper(watcher: 'MetricWatcher') -> None:
+        nonlocal failing
+        old_failing = failing
+        new_failing = any(w.failing for w in watchers)
+        on_failure_callback(watcher.label, watcher.failing)
+
+        failing = new_failing
+
+        if new_failing == (not old_failing):
+            on_failure_trigger_callback(new_failing)
+
+    for cluster, config in _get_metric_configs_for_service_by_cluster(service, soa_dir).items():
+        log.info(f'Processing configs for {service} in {cluster}...')
+
+        rollback_conditions = config.get('conditions')
+        check_interval_s = config.get('check_interval_s')
+        if not rollback_conditions:
+            log.warning(f'{cluster} has a rollback file - but no conditions!')
+            continue
+
+        splunk_conditions = rollback_conditions.get('splunk')
+        if splunk_conditions:
+            if splunk_auth_callback is None:
+                msg = 'Splunk auth not configured, cowardly refusing to continue'
+                log.warning(msg)
+                raise MissingConfigException(msg)
+            else:
+                watchers.extend(
+                    create_splunk_metricwatchers(
+                        splunk_conditions=splunk_conditions,
+                        check_interval_s=check_interval_s,
+                        on_failure_callback=callback_wrapper,
+                        auth_callback=splunk_auth_callback,
+                    ),
+                )
     return threads, watchers

--- a/tests/rollbacks/test_metrics.py
+++ b/tests/rollbacks/test_metrics.py
@@ -1,0 +1,49 @@
+import yaml
+
+from sticht.rollbacks.metrics import watch_metrics_for_service
+from sticht.rollbacks.sources.splunk import SplunkMetricWatcher
+from sticht.rollbacks.types import SplunkAuth
+
+TEST_SPLUNK_AUTH = SplunkAuth(
+    host='splank.yelp.com',
+    port=1234,
+    username='username',
+    password='totally_a_password',
+)
+
+
+def test_watch_metrics_for_service_creates_watchers(tmp_path):
+    service = 'serviceA'
+    soa_dir = tmp_path
+    (soa_dir / service).mkdir()
+    (soa_dir / service / 'rollback-test-cluster.yaml').write_text(
+        yaml.safe_dump(
+            {
+                'conditions': {
+                    'splunk': [
+                        {
+                            'label': 'label',
+                            'query': 'hwat',
+                            'lower_bound': 1,
+                        },
+                    ],
+                },
+            },
+        ),
+    )
+
+    _, watchers = watch_metrics_for_service(
+        service=service,
+        soa_dir=soa_dir,
+        on_failure_callback=lambda _, __: None,
+        on_failure_trigger_callback=lambda _: None,
+        splunk_auth_callback=lambda: TEST_SPLUNK_AUTH,
+    )
+
+    assert len(watchers) == 1
+    assert watchers[0] == SplunkMetricWatcher(
+        label='label',
+        query='hwat',
+        on_failure_callback=lambda _: None,
+        auth_callback=lambda: TEST_SPLUNK_AUTH,
+    )


### PR DESCRIPTION
This commit teaches watch_metrics_for_service (the interface callers will use to create MetricWatchers) how to actually go ahead and create these watchers in the first place.

That said, we still need to add the code to actually add the threads that will be invoking the actual metric queries.