### PR TITLE
Add a way to create watchers from config

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -36,7 +36,7 @@ repos:
     hooks:
       - id: autopep8
   - repo: https://gitlab.com/pycqa/flake8
-    rev: 3.7.1
+    rev: 4.0.1
     hooks:
       - id: flake8
   - repo: https://github.com/asottile/reorder_python_imports

--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -1,12 +1,12 @@
 import abc
 from typing import List
 from typing import Optional
-from typing import Tuple
 
 from sticht.rollbacks.metrics import watch_metrics_for_service
 from sticht.rollbacks.slo import SLOWatcher
 from sticht.rollbacks.slo import watch_slos_for_service
 from sticht.rollbacks.types import MetricWatcher
+from sticht.rollbacks.types import SplunkAuth
 from sticht.slack import Emoji
 from sticht.slack import SlackDeploymentProcess
 
@@ -179,7 +179,7 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
         raise NotImplementedError()
 
     @abc.abstractmethod
-    def get_splunk_api_token(self) -> Tuple[str, str]:
+    def get_splunk_api_token(self) -> SplunkAuth:
         raise NotImplementedError()
 
     @abc.abstractmethod

--- a/tests/rollbacks/sources/test_splunk.py
+++ b/tests/rollbacks/sources/test_splunk.py
@@ -139,3 +139,27 @@ def test_login_calls_auth_callback():
     ):
         watcher._splunk_login()
     mock_credentials_callback.assert_called_once()
+
+
+@pytest.mark.parametrize(
+    'check_interval_s', (
+        None,
+        0,
+        123,
+    ),
+)
+def test_from_config(check_interval_s):
+    assert SplunkMetricWatcher.from_config(
+        config={
+            'label': 'label',
+            'query': 'query',
+        },
+        check_interval_s=check_interval_s,
+        on_failure_callback=lambda _: None,
+        auth_callback=lambda: TEST_SPLUNK_AUTH,
+    ) == SplunkMetricWatcher(
+        label='label',
+        query='query',
+        on_failure_callback=lambda _: None,
+        auth_callback=lambda: TEST_SPLUNK_AUTH,
+    )


### PR DESCRIPTION
This commit creates some scaffolding for creating MetricWatchers (specifically SplunkMetricWatchers) from our autorollback config files