### PR TITLE
Kkasp/compinfra 1135 share splunk object

### DIFF
--- a/sticht/rollbacks/metrics.py
+++ b/sticht/rollbacks/metrics.py
@@ -65,7 +65,6 @@ def watch_metrics_for_service(
 
         splunk_conditions = rollback_conditions.get('splunk')
         if splunk_conditions:
-            print(splunk_auth)
             if splunk is None:
                 splunk = splunklib.client.connect(
                     host=splunk_auth.host,

--- a/sticht/rollbacks/sources/splunk.py
+++ b/sticht/rollbacks/sources/splunk.py
@@ -31,19 +31,7 @@ class SplunkMetricWatcher(MetricWatcher):
     ) -> None:
         super().__init__(label, on_failure_callback)
         self._query = query
-        # TODO: should we share a global version of this so that we're
-        # not logging-in a million times?
-        # self._splunk: Optional[splunklib.client.Service] = None
         self._splunk = splunk
-
-    # def _splunk_login(self) -> None:
-    #     auth = self._auth_callback()
-    #     self._splunk = splunklib.client.connect(
-    #         host=auth.host,
-    #         port=auth.port,
-    #         username=auth.username,
-    #         password=auth.password,
-    #     )
 
     def __eq__(self, other: object) -> bool:
         if not isinstance(other, SplunkMetricWatcher):

--- a/tests/rollbacks/sources/test_splunk.py
+++ b/tests/rollbacks/sources/test_splunk.py
@@ -99,48 +99,6 @@ def test__get_splunk_result(results, expected_results):
         assert watcher._get_splunk_results(mock_job) == expected_results
 
 
-def test_query_logins_on_first_attempt():
-    watcher = SplunkMetricWatcher(
-        label='test_query',
-        query='what does it all mean',
-        on_failure_callback=lambda _: None,
-        splunk=TEST_SPLUNK_AUTH,
-    )
-
-    def _login_side_effect(_):
-        watcher._splunk = mock.Mock(spec=splunklib.client.Service)
-
-    with mock.patch(
-        'sticht.rollbacks.sources.splunk.SplunkMetricWatcher._get_splunk_results',
-        autospec=True,
-    ), mock.patch(
-        'sticht.rollbacks.sources.splunk.SplunkMetricWatcher.process_result',
-        autospec=True,
-    ), mock.patch(
-        'sticht.rollbacks.sources.splunk.SplunkMetricWatcher._splunk_login',
-        autospec=True,
-        side_effect=_login_side_effect,
-    ) as mock_login:
-        watcher.query()
-        mock_login.assert_called_once()
-
-
-# def test_login_calls_auth_callback(): # TODO: remove?
-    # mock_credentials_callback = mock.Mock()
-    # watcher = SplunkMetricWatcher(
-    #     label='test_query',
-    #     query='what does it all mean',
-    #     on_failure_callback=lambda _: None,
-    #     auth_callback=mock_credentials_callback,
-    # )
-    # with mock.patch(
-    #     'sticht.rollbacks.sources.splunk.splunklib.client.connect',
-    #     autospec=True,
-    # ):
-    #     watcher._splunk_login()
-    # mock_credentials_callback.assert_called_once()
-
-
 @pytest.mark.parametrize(
     'check_interval_s', (
         None,

--- a/tests/rollbacks/sources/test_splunk.py
+++ b/tests/rollbacks/sources/test_splunk.py
@@ -20,7 +20,7 @@ def test_query_calls_process_results():
         label='test_query',
         query='what does it all mean',
         on_failure_callback=lambda _: None,
-        auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk=TEST_SPLUNK_AUTH,
     )
     watcher._splunk = mock.Mock(spec=splunklib.client.Service)
 
@@ -49,7 +49,7 @@ def test__get_splunk_result_respects_query_timeout():
             label='test_query',
             query='what does it all mean',
             on_failure_callback=lambda _: None,
-            auth_callback=lambda: TEST_SPLUNK_AUTH,
+            splunk=TEST_SPLUNK_AUTH,
         )
         watcher._splunk = mock.Mock(spec=splunklib.client.Service)
 
@@ -94,7 +94,7 @@ def test__get_splunk_result(results, expected_results):
             label='test_query',
             query='what does it all mean',
             on_failure_callback=lambda _: None,
-            auth_callback=lambda: TEST_SPLUNK_AUTH,
+            splunk=TEST_SPLUNK_AUTH,
         )
         assert watcher._get_splunk_results(mock_job) == expected_results
 
@@ -104,7 +104,7 @@ def test_query_logins_on_first_attempt():
         label='test_query',
         query='what does it all mean',
         on_failure_callback=lambda _: None,
-        auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk=TEST_SPLUNK_AUTH,
     )
 
     def _login_side_effect(_):
@@ -125,20 +125,20 @@ def test_query_logins_on_first_attempt():
         mock_login.assert_called_once()
 
 
-def test_login_calls_auth_callback():
-    mock_credentials_callback = mock.Mock()
-    watcher = SplunkMetricWatcher(
-        label='test_query',
-        query='what does it all mean',
-        on_failure_callback=lambda _: None,
-        auth_callback=mock_credentials_callback,
-    )
-    with mock.patch(
-        'sticht.rollbacks.sources.splunk.splunklib.client.connect',
-        autospec=True,
-    ):
-        watcher._splunk_login()
-    mock_credentials_callback.assert_called_once()
+# def test_login_calls_auth_callback(): # TODO: remove?
+    # mock_credentials_callback = mock.Mock()
+    # watcher = SplunkMetricWatcher(
+    #     label='test_query',
+    #     query='what does it all mean',
+    #     on_failure_callback=lambda _: None,
+    #     auth_callback=mock_credentials_callback,
+    # )
+    # with mock.patch(
+    #     'sticht.rollbacks.sources.splunk.splunklib.client.connect',
+    #     autospec=True,
+    # ):
+    #     watcher._splunk_login()
+    # mock_credentials_callback.assert_called_once()
 
 
 @pytest.mark.parametrize(
@@ -156,10 +156,10 @@ def test_from_config(check_interval_s):
         },
         check_interval_s=check_interval_s,
         on_failure_callback=lambda _: None,
-        auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk=TEST_SPLUNK_AUTH,
     ) == SplunkMetricWatcher(
         label='label',
         query='query',
         on_failure_callback=lambda _: None,
-        auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk=TEST_SPLUNK_AUTH,
     )

--- a/tests/rollbacks/test_metrics.py
+++ b/tests/rollbacks/test_metrics.py
@@ -37,7 +37,7 @@ def test_watch_metrics_for_service_creates_watchers(tmp_path):
         soa_dir=soa_dir,
         on_failure_callback=lambda _, __: None,
         on_failure_trigger_callback=lambda _: None,
-        splunk_auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk_auth=TEST_SPLUNK_AUTH,
     )
 
     assert len(watchers) == 1
@@ -45,5 +45,5 @@ def test_watch_metrics_for_service_creates_watchers(tmp_path):
         label='label',
         query='hwat',
         on_failure_callback=lambda _: None,
-        auth_callback=lambda: TEST_SPLUNK_AUTH,
+        splunk=TEST_SPLUNK_AUTH,
     )

--- a/tests/rollbacks/test_metrics.py
+++ b/tests/rollbacks/test_metrics.py
@@ -1,3 +1,5 @@
+from unittest import mock
+
 import yaml
 
 from sticht.rollbacks.metrics import watch_metrics_for_service
@@ -32,13 +34,18 @@ def test_watch_metrics_for_service_creates_watchers(tmp_path):
         ),
     )
 
-    _, watchers = watch_metrics_for_service(
-        service=service,
-        soa_dir=soa_dir,
-        on_failure_callback=lambda _, __: None,
-        on_failure_trigger_callback=lambda _: None,
-        splunk_auth=TEST_SPLUNK_AUTH,
-    )
+    with mock.patch(
+        'sticht.rollbacks.sources.splunk.splunklib.client',
+        autospec=True,
+    ) as mock_client:
+        mock_client.connect.return_value = mock.MagicMock()
+        _, watchers = watch_metrics_for_service(
+            service=service,
+            soa_dir=soa_dir,
+            on_failure_callback=lambda _, __: None,
+            on_failure_trigger_callback=lambda _: None,
+            splunk_auth=TEST_SPLUNK_AUTH,
+        )
 
     assert len(watchers) == 1
     assert watchers[0] == SplunkMetricWatcher(


### PR DESCRIPTION
Splunk_lib is thread safe so we can share a splunk object between watchers just so we aren't as wasteful.