### PR TITLE
Splunk parsing logic

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -154,12 +154,13 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
                     )
                     for metric_watcher in unknown:
                         metric_text_components.append(f'{metric_watcher.label}\n')
-                
+
                 if len(previously_failing) > 0:
                     metric_text_components.extend(
                         [
                             Emoji(':grimacing:'),
-                            f'{len(previously_failing)} rollback conditions were failing before deploy, and will be ignored:\n',
+                            f'{len(previously_failing)} rollback conditions were failing before deploy, ',
+                            'and will be ignored:\n',
                         ],
                     )
                     for metric_watcher in previously_failing:
@@ -177,8 +178,6 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
                         metric_text_components.append(
                             f'The remaining {remaining} rollback conditions are currently passing.',
                         )
-
-                
 
             if summary:
                 # For summary, only display emojis.

--- a/tests/rollbacks/sources/test_splunk.py
+++ b/tests/rollbacks/sources/test_splunk.py
@@ -18,6 +18,7 @@ def test_query_calls_process_results():
     watcher = SplunkMetricWatcher(
         label='test_query',
         query='what does it all mean',
+        query_type='results',
         on_failure_callback=lambda _: None,
         auth_callback=lambda: TEST_SPLUNK_AUTH,
     )
@@ -70,6 +71,7 @@ def test__get_splunk_result(results, expected_results):
         watcher = SplunkMetricWatcher(
             label='test_query',
             query='what does it all mean',
+            query_type='results',
             on_failure_callback=lambda _: None,
             auth_callback=lambda: TEST_SPLUNK_AUTH,
         )
@@ -80,6 +82,7 @@ def test_query_logins_on_first_attempt():
     watcher = SplunkMetricWatcher(
         label='test_query',
         query='what does it all mean',
+        query_type='results',
         on_failure_callback=lambda _: None,
         auth_callback=lambda: TEST_SPLUNK_AUTH,
     )
@@ -107,6 +110,7 @@ def test_login_calls_auth_callback():
     watcher = SplunkMetricWatcher(
         label='test_query',
         query='what does it all mean',
+        query_type='results',
         on_failure_callback=lambda _: None,
         auth_callback=mock_credentials_callback,
     )
@@ -130,6 +134,7 @@ def test_from_config(check_interval_s):
         config={
             'label': 'label',
             'query': 'query',
+            'query_type': 'type',
         },
         check_interval_s=check_interval_s,
         on_failure_callback=lambda _: None,
@@ -137,6 +142,7 @@ def test_from_config(check_interval_s):
     ) == SplunkMetricWatcher(
         label='label',
         query='query',
+        query_type='type',
         on_failure_callback=lambda _: None,
         auth_callback=lambda: TEST_SPLUNK_AUTH,
     )

--- a/tests/rollbacks/test_metrics.py
+++ b/tests/rollbacks/test_metrics.py
@@ -27,6 +27,7 @@ def test_watch_metrics_for_service_creates_watchers(mock_splunk_metric_watcher_q
                         {
                             'label': 'label',
                             'query': 'hwat',
+                            'query_type': 'type',
                             'lower_bound': 1,
                         },
                     ],
@@ -47,6 +48,7 @@ def test_watch_metrics_for_service_creates_watchers(mock_splunk_metric_watcher_q
     assert watchers[0] == SplunkMetricWatcher(
         label='label',
         query='hwat',
+        query_type='type',
         on_failure_callback=lambda _: None,
         auth_callback=lambda: TEST_SPLUNK_AUTH,
     )


### PR DESCRIPTION
Following PR to be merged after https://github.com/Yelp/sticht/pull/41.

SplunkMetricWatcher threads will parse logic based on their query_type. 