### PR TITLE
GH Action to publish only on push to master

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,9 +1,8 @@
 ---
 name: sticht-ci
 on:
-  push:
-    branches:
-      - master
+  push
+
 jobs:
   publish:
     runs-on: ubuntu-latest
@@ -15,14 +14,5 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: 3.6
-
-    - name: Install Python dependencies
-      run: pip install wheel
-
-    - name: Create a Wheel file and source distribution
-      run: python setup.py sdist bdist_wheel
-
-    - name: Publish distribution package to PyPI
-      uses: pypa/gh-action-pypi-publish@v1.2.2
-      with:
-        password: ${{ secrets.pypi_password }}
+    - run: pip install tox
+    - run: tox

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,9 @@
 ---
 name: sticht-ci
-on: [push, release]
+on:
+  push:
+    branches:
+      - master
 jobs:
   publish:
     runs-on: ubuntu-latest

--- a/.github/workflows/pypi.yml
+++ b/.github/workflows/pypi.yml
@@ -1,0 +1,30 @@
+---
+name: sticht-pypi
+
+on:
+  push:
+    tags:
+      - v*
+
+jobs:
+  publish:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Checkout Repo
+      uses: actions/checkout@v2
+
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.6
+
+    - name: Install Python dependencies
+      run: pip install wheel
+
+    - name: Create a Wheel file and source distribution
+      run: python setup.py sdist bdist_wheel
+
+    - name: Publish distribution package to PyPI
+      uses: pypa/gh-action-pypi-publish@v1.2.2
+      with:
+        password: ${{ secrets.pypi_password }}


### PR DESCRIPTION
ci.yml
- Runs tests with tox

pypi
- Pushes to public pypi if we run the release with the git tags.