### PR TITLE
Pass trigger for start and cancel auto_rollback_countdown

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -278,16 +278,13 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
             self.trigger('metrics_stopped_failing')
         self.update_slack()
 
-    # TODO: figure out what to do wrt to these triggers now that we have SLOs and metric query
-    # rollacks
-
-    def start_auto_rollback_countdown(self, extra_text) -> None:
+    def start_auto_rollback_countdown(self, trigger: str, extra_text: str) -> None:
         self.start_timer(
-            self.get_auto_rollback_delay(),
-            'rollback_slo_failure',
-            'automatically roll back',
+            timeout=self.get_auto_rollback_delay(),
+            trigger=trigger,
+            message_verb='automatically roll back',
             extra_text=extra_text,
         )
 
-    def cancel_auto_rollback_countdown(self) -> None:
-        self.cancel_timer('rollback_slo_failure')
+    def cancel_auto_rollback_countdown(self, trigger: str) -> None:
+        self.cancel_timer(trigger=trigger)

--- a/sticht/state_machine.py
+++ b/sticht/state_machine.py
@@ -123,6 +123,8 @@ class DeploymentProcess(abc.ABC):
             self.event_loop.call_soon_threadsafe(self.finished_event.set)
 
     def start_timer(self, timeout, trigger, message_verb, extra_text=''):
+        # TODO: COMPINFRA-1140 - at the very least, pass trigger in to cancel_time(),
+        # but probably some more stuff to do in cancel/restart_timer
         self.cancel_timer()
         timer_start = time.time()
         timer_end = timer_start + timeout


### PR DESCRIPTION
These are the changes for metric rollback triggers. Pairs with [paasta PR](https://github.com/Yelp/paasta/pull/3459) that adds the relevant transitions.

This removes the hardcoding put in place for rollback_slo_failure.