### PR TITLE
Pass trigger when calling cancel_timer

### DIFF
--- a/sticht/state_machine.py
+++ b/sticht/state_machine.py
@@ -123,7 +123,7 @@ class DeploymentProcess(abc.ABC):
             self.event_loop.call_soon_threadsafe(self.finished_event.set)
 
     def start_timer(self, timeout, trigger, message_verb, extra_text=''):
-        self.cancel_timer()
+        self.cancel_timer(trigger=trigger)
         timer_start = time.time()
         timer_end = timer_start + timeout
         formatted_time = datetime.datetime.fromtimestamp(timer_end).strftime('%X')


### PR DESCRIPTION
During an auto_rollback loop any calls to start_timer will automatically call cancel_timer() without passing a trigger. This is fine when we only use SLOs but when we use metrics there might be a conflict. This change passes the trigger in so that only the timer for the trigger in question is reset.