### PR TITLE
Refactor Metric Watchers Logic

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -126,10 +126,8 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
             return ''
 
     def get_metric_text(self, summary: bool) -> str:
-        metric_text_components = []
         if self.metric_watchers is not None and len(self.metric_watchers) > 0:
             failing = [w for w in self.metric_watchers if w.failing]
-
             if failing:
                 metric_text_components = [
                     Emoji(':alert:'),
@@ -141,7 +139,7 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
                 unknown = [
                     w
                     for w in self.metric_watchers
-                    if w.bad_before_mark is None
+                    if w.bad_before_mark is None or w.bad_after_mark is None
                 ]
 
                 bad_before_mark = [w for w in self.metric_watchers if w.bad_before_mark]

--- a/sticht/rollbacks/metrics.py
+++ b/sticht/rollbacks/metrics.py
@@ -56,7 +56,6 @@ def watch_metrics_for_service(
         log.info(f'Processing configs for {service} in {cluster}...')
 
         rollback_conditions = config.get('conditions')
-        check_interval_s = config.get('check_interval_s')
         if not rollback_conditions:
             log.warning(f'{cluster} has a rollback file - but no conditions!')
             continue
@@ -66,7 +65,6 @@ def watch_metrics_for_service(
             watchers.extend(
                 create_splunk_metricwatchers(
                     splunk_conditions=splunk_conditions,
-                    check_interval_s=check_interval_s,
                     on_failure_callback=callback_wrapper,
                     auth_callback=splunk_auth_callback,
                 ),

--- a/sticht/rollbacks/types.py
+++ b/sticht/rollbacks/types.py
@@ -76,7 +76,6 @@ class MetricWatcher:
     def from_config(
         cls: Type[MetricWatcherT],
         config: BaseRule,
-        check_interval_s: Optional[float],
         on_failure_callback: Callable[['MetricWatcher'], None],
         auth_callback: Optional[Callable[[], Any]] = None,
     ) -> MetricWatcherT:


### PR DESCRIPTION
Changed the is_window_bad logic to look for instances when one or both of the bounds are present.

Also changed the check_interval_s to be created when the SplunkMetricWatcher is initialized. Before, it was okay to do because we weren't doing anything with the variable, but initializing when the object is created makes it easier to grab it when we're running watch().

Also added a change in get_metric_text to make it look similar to get_slo_text.