### PR TITLE
Fix scribereader imports to work with newer package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,8 @@ setup(
     ],
     extras_require={
         'yelp_internal': [
-            'yelp-clog>=2.12.1',
+            'yelp-clog>=7.1.1',
+            'scribereader>=1.1.1'
             'slo-transcoder>=3.2.3',
         ],
     },

--- a/setup.py
+++ b/setup.py
@@ -34,7 +34,7 @@ setup(
     extras_require={
         'yelp_internal': [
             'yelp-clog>=7.1.1',
-            'scribereader>=1.1.1'
+            'scribereader>=1.1.1',
             'slo-transcoder>=3.2.3',
         ],
     },

--- a/sticht/slack.py
+++ b/sticht/slack.py
@@ -29,8 +29,8 @@ from sticht.state_machine import DeploymentProcess
 
 try:
     from scribereader import scribereader
-    from clog.readers import construct_conn_msg
-    from clog.readers import find_tail_host
+    from scribereader.clog.readers import construct_conn_msg
+    from scribereader.clog.readers import find_tail_host
 except ImportError:
     scribereader = None
     construct_conn_msg = None


### PR DESCRIPTION
After https://github.com/Yelp/paasta/pull/3868 sticht can no longer read from scribe in order to detect slack button presses.

This is a quick fix to the imports that are needed for sticht to support scribereader as-is.

We may need to update this to use the replacement log infra later, but slack webhook logs are currently still going to our default scribe stream. 


## Testing
Building the wheel w/ `python setup.py bdist_wheel`  and then installing this in a local paasta build does fix slack functionality: 
<img width="725" alt="Screenshot 2024-06-05 at 12 41 33 PM" src="https://github.com/Yelp/sticht/assets/2119545/f895eff4-8462-42b7-8c47-c00f0c5a060f">
