### PR TITLE
asyncio.Event() should not be passed a loop arg/kwarg

### DIFF
--- a/sticht/state_machine.py
+++ b/sticht/state_machine.py
@@ -63,7 +63,7 @@ class DeploymentProcess(abc.ABC):
     def __init__(self):
 
         self.event_loop = asyncio.get_event_loop()
-        self.finished_event = asyncio.Event(loop=self.event_loop)
+        self.finished_event = asyncio.Event()
         self.timer_running = False
 
         self.machine = transitions.extensions.LockedMachine(


### PR DESCRIPTION
This was deprecated starting in py3.8 and removed in py3.10