### PR TITLE
PAASTA-18913: Add AlertManagerWatcher class

### DIFF
--- a/sticht/rollbacks/sources/alertmanager.py
+++ b/sticht/rollbacks/sources/alertmanager.py
@@ -1,0 +1,126 @@
+import logging
+import time
+from datetime import datetime
+from datetime import timezone
+from typing import List
+from typing import Optional
+
+from typing_extensions import Protocol
+
+from sticht.alertmanager import Alert
+from sticht.alertmanager import AlertmanagerClient
+
+log = logging.getLogger(__name__)
+
+_DEFAULT_CHECK_INTERVAL_S = 30
+
+
+def _parse_iso_timestamp(ts: str) -> float:
+    ts = ts.replace('Z', '+00:00')
+    return datetime.fromisoformat(ts).replace(tzinfo=timezone.utc).timestamp()
+
+
+class IndividualAlertCallback(Protocol):
+    def __call__(self, label: str, *, failing: bool) -> None: ...
+
+
+class AllAlertCallback(Protocol):
+    def __call__(self, *, failing: bool) -> None: ...
+
+
+class AlertManagerWatcher:
+    """Polls AlertManager for firing alerts, ignoring those that predate the deploy.
+
+    Args:
+        alertmanager_url: Base URL for the target AlertManager - e.g., alertmanager.mycoolcompany.com
+        filters: AlertManager filter matchers (e.g. ['alertname=HighLatency', 'service=myapp']) - at Yelp, callers of
+            sticht will pre-populate the expected filters (e.g., PaaSTA will pass down all the various filters that
+            we're expecting to have alerts match on).
+            Multiple filter groups can be passed to achieve OR semantics - each group is queried separately and results
+            are ORed.
+        individual_alert_callback: callback function that takes two parameters: a label for the alert in question
+            as well a boolean representing if that alert is active or not.
+            the label is used purely for notifying users what alerts are now firing (or no longer firing) based on the
+            boolean value
+        all_alert_callback: callback function that takes a single boolean representing if any alert is failing.
+            if so, the expectation is that this callback will potentially trigger a state machine transition towards
+            the failing or recovered states (e.g., more or less like what the *_slo_callback functions do)
+        deploy_start_time: Unix timestamp; alerts firing before this time are treated as pre-existing and ignored
+            (unless they recover mid-deploy).
+        check_interval_s: how often (in seconds) to poll AlertManager for alerts
+    """
+
+    def __init__(
+        self,
+        alertmanager_url: str,
+        filters: List[List[str]],
+        individual_alert_callback: IndividualAlertCallback,
+        all_alert_callback: AllAlertCallback,
+        # XXX: our CEP also includes some tunables for how many polls alerts need to be firing/not-firing for
+        # that we'll want to add here later
+        check_interval_s: int = _DEFAULT_CHECK_INTERVAL_S,
+        deploy_start_time: Optional[float] = None,
+    ) -> None:
+        self.filters = filters
+        self.check_interval_s = check_interval_s
+        self.deploy_start_time = deploy_start_time if deploy_start_time is not None else time.time()
+        self.active_alerts: set[str] = set()
+        self.individual_alert_callback = individual_alert_callback
+        self.all_alert_callback = all_alert_callback
+        self._client = AlertmanagerClient(alertmanager_url)
+
+    def query(self) -> None:
+        all_alerts: List[Alert] = []
+        for filter_group in self.filters:
+            try:
+                all_alerts.extend(self._client.fetch_alerts(filters=filter_group))
+            except Exception:
+                log.exception(
+                    f'Error fetching alerts from AlertManager for filter group {filter_group}, '
+                    f'continuing with remaining filter groups',
+                )
+        self.process_result(all_alerts)
+
+    def process_result(
+        self,
+        alerts: List['Alert'],
+    ) -> None:
+        # NOTE: this is just tracking alert names for now - we can store the whole payload if necessary later on
+        # ...but then we'll definitely need to change the set shenanigans below if we just swap things in-place here
+        alerts_seen: set[str] = set()
+        for alert in alerts:
+            try:
+                starts_at = _parse_iso_timestamp(alert['startsAt'])
+            except (KeyError, ValueError):
+                starts_at = self.deploy_start_time
+                log.warning(
+                    f'Could not parse startsAt for alert, assuming alert was triggered during the deployment: {alert}',
+                )
+
+            if starts_at < self.deploy_start_time:
+                # XXX: print message about excluded alert?
+                continue
+
+            alerts_seen.add(alert['labels']['alertname'])
+
+        # ping users about newly failing alerts
+        new_alerts = alerts_seen - self.active_alerts
+        for alert in new_alerts:
+            self.individual_alert_callback(alert, failing=True)
+
+        # ...and then about alerts that have since recovered
+        resolved_alerts = self.active_alerts - alerts_seen
+        for alert in resolved_alerts:
+            self.individual_alert_callback(alert, failing=False)
+
+        # ...and then potentially transition through the state machine if there's been any alert changes
+        if self.active_alerts != alerts_seen:
+            self.all_alert_callback(failing=len(alerts_seen) > 0)
+
+        # ...and then finally: store the current alerts for the next iteration to compare to
+        self.active_alerts = alerts_seen
+
+    def watch(self) -> None:
+        while True:
+            self.query()
+            time.sleep(self.check_interval_s)

--- a/tests/rollbacks/sources/test_alertmanager.py
+++ b/tests/rollbacks/sources/test_alertmanager.py
@@ -1,0 +1,85 @@
+from datetime import datetime
+from datetime import timezone
+from unittest import mock
+
+from sticht.alertmanager import AlertmanagerClient
+from sticht.rollbacks.sources.alertmanager import AlertManagerWatcher
+from sticht.rollbacks.sources.alertmanager import AllAlertCallback
+from sticht.rollbacks.sources.alertmanager import IndividualAlertCallback
+
+
+TEST_ALERTMANAGER_URL = 'http://alertmanager.example.com'
+TEST_FILTERS = [['alertname=HighLatency', 'service=myapp']]
+TEST_DEPLOY_START_TIME = 1000.0
+
+
+def _make_watcher(individual_alert_callback=None, all_alert_callback=None):
+    watcher = AlertManagerWatcher(
+        alertmanager_url=TEST_ALERTMANAGER_URL,
+        filters=TEST_FILTERS,
+        individual_alert_callback=individual_alert_callback or mock.Mock(spec=IndividualAlertCallback),
+        all_alert_callback=all_alert_callback or mock.Mock(spec=AllAlertCallback),
+        deploy_start_time=TEST_DEPLOY_START_TIME,
+    )
+    watcher._client = mock.Mock(spec=AlertmanagerClient)
+    return watcher
+
+
+def _ts_iso(epoch):
+    return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
+
+
+def _make_alert(alertname, starts_at_epoch):
+    return {'labels': {'alertname': alertname}, 'startsAt': _ts_iso(starts_at_epoch)}
+
+
+def test_process_result_new_alerts():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+
+    watcher.process_result([_make_alert('HighLatency', 1500.0)])
+
+    individual_cb.assert_called_once_with('HighLatency', failing=True)
+    all_cb.assert_called_once_with(failing=True)
+    assert watcher.active_alerts == {'HighLatency'}
+
+
+def test_process_result_excludes_pre_deploy_alerts():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+
+    # alert before deploy is excluded
+    watcher.process_result([_make_alert('OldAlert', 500.0)])
+    individual_cb.assert_not_called()
+    all_cb.assert_not_called()
+    assert watcher.active_alerts == set()
+
+    # alert with unparseable startsAt defaults to deploy_start_time (NOT excluded)
+    watcher.process_result([{'labels': {'alertname': 'BadTimestamp'}, 'startsAt': 'garbage'}])
+    individual_cb.assert_called_once_with('BadTimestamp', failing=True)
+
+
+def test_process_result_resolved_alerts():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+    watcher.active_alerts = {'OldAlert'}
+
+    watcher.process_result([])
+
+    individual_cb.assert_called_once_with('OldAlert', failing=False)
+    all_cb.assert_called_once_with(failing=False)
+    assert watcher.active_alerts == set()
+
+
+def test_process_result_no_change_no_callbacks():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+
+    watcher.process_result([])
+
+    individual_cb.assert_not_called()
+    all_cb.assert_not_called()


### PR DESCRIPTION
This isn't hooked up to anything yet (and the AlertManager API calls will need to move to our soon-to-be-created AlertManager client), but this is probably a good starting point for how we'll have sticht handle AlertManager as a source of autorollbacks.

Unlike the SLO-based rollback source (where we made one watcher per-SLO), we simply make one watcher since we can get all the information we need in one shot from AlertManager :)

I've left a decent number of XXX/TODO comments, but mostly since I'm putting this up a little early as I'm about to be out for a week :p