### PR TITLE
Add dry-run functionality for alertmanager rollbacks

### DIFF
--- a/sticht/rollbacks/base.py
+++ b/sticht/rollbacks/base.py
@@ -188,11 +188,12 @@ class RollbackSlackDeploymentProcess(SlackDeploymentProcess, abc.ABC):
             self.trigger('slos_stopped_failing')
         self.update_slack()
 
-    def individual_alertmanager_callback(self, label: str, failing: bool) -> None:
+    def individual_alertmanager_callback(self, label: str, failing: bool, dry_run: bool = False) -> None:
+        prefix = '[DRY-RUN] ' if dry_run else ''
         if failing:
-            self.update_slack_thread(f'AlertManager alert started firing: {label}', color='danger')
+            self.update_slack_thread(f'{prefix}AlertManager alert started firing: {label}', color='danger')
         else:
-            self.update_slack_thread(f'AlertManager alert resolved: {label}', color='good')
+            self.update_slack_thread(f'{prefix}AlertManager alert resolved: {label}', color='good')
         self.update_slack()
 
     def all_alertmanager_callback(self, failing: bool) -> None:

--- a/sticht/rollbacks/sources/alertmanager.py
+++ b/sticht/rollbacks/sources/alertmanager.py
@@ -15,6 +15,8 @@ from sticht.alertmanager import AlertmanagerClient
 log = logging.getLogger(__name__)
 
 _DEFAULT_CHECK_INTERVAL_S = 30
+# XXX: should we maybe have this be passed down from paasta so that it's not hardcoded here?
+_DRY_RUN_LABEL = 'paasta_rollback_dry_run'
 
 
 def _parse_iso_timestamp(ts: str) -> float:
@@ -23,7 +25,7 @@ def _parse_iso_timestamp(ts: str) -> float:
 
 
 class IndividualAlertCallback(Protocol):
-    def __call__(self, label: str, *, failing: bool) -> None: ...
+    def __call__(self, label: str, *, failing: bool, dry_run: bool = False) -> None: ...
 
 
 class AllAlertCallback(Protocol):
@@ -67,6 +69,7 @@ class AlertManagerWatcher:
         self.check_interval_s = check_interval_s
         self.deploy_start_time = deploy_start_time if deploy_start_time is not None else time.time()
         self.active_alerts: set[str] = set()
+        self.active_dry_run_alerts: set[str] = set()
         self.individual_alert_callback = individual_alert_callback
         self.all_alert_callback = all_alert_callback
         self._client = AlertmanagerClient(alertmanager_url)
@@ -90,6 +93,8 @@ class AlertManagerWatcher:
         # NOTE: this is just tracking alert names for now - we can store the whole payload if necessary later on
         # ...but then we'll definitely need to change the set shenanigans below if we just swap things in-place here
         alerts_seen: set[str] = set()
+        dry_run_alerts_seen: set[str] = set()
+
         for alert in alerts:
             try:
                 starts_at = _parse_iso_timestamp(alert['startsAt'])
@@ -103,7 +108,18 @@ class AlertManagerWatcher:
                 # XXX: print message about excluded alert?
                 continue
 
-            alerts_seen.add(alert['labels']['alertname'])
+            alertname = alert['labels']['alertname']
+            if alert['labels'].get(_DRY_RUN_LABEL) == 'true':
+                dry_run_alerts_seen.add(alertname)
+            else:
+                alerts_seen.add(alertname)
+
+        # notify about newly failing dry-run alerts (informational only)
+        for alert in dry_run_alerts_seen - self.active_dry_run_alerts:
+            self.individual_alert_callback(alert, failing=True, dry_run=True)
+        for alert in self.active_dry_run_alerts - dry_run_alerts_seen:
+            self.individual_alert_callback(alert, failing=False, dry_run=True)
+        self.active_dry_run_alerts = dry_run_alerts_seen
 
         # ping users about newly failing alerts
         new_alerts = alerts_seen - self.active_alerts

--- a/tests/rollbacks/sources/test_alertmanager.py
+++ b/tests/rollbacks/sources/test_alertmanager.py
@@ -29,8 +29,11 @@ def _ts_iso(epoch):
     return datetime.fromtimestamp(epoch, tz=timezone.utc).isoformat()
 
 
-def _make_alert(alertname, starts_at_epoch):
-    return {'labels': {'alertname': alertname}, 'startsAt': _ts_iso(starts_at_epoch)}
+def _make_alert(alertname, starts_at_epoch, dry_run=False):
+    labels = {'alertname': alertname}
+    if dry_run:
+        labels['paasta_rollback_dry_run'] = 'true'
+    return {'labels': labels, 'startsAt': _ts_iso(starts_at_epoch)}
 
 
 def test_process_result_new_alerts():
@@ -82,4 +85,46 @@ def test_process_result_no_change_no_callbacks():
     watcher.process_result([])
 
     individual_cb.assert_not_called()
+    all_cb.assert_not_called()
+
+
+def test_process_result_dry_run_alert_does_not_trigger_all_callback():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+
+    watcher.process_result([_make_alert('DryRunAlert', 1500.0, dry_run=True)])
+
+    individual_cb.assert_called_once_with('DryRunAlert', failing=True, dry_run=True)
+    all_cb.assert_not_called()
+    assert watcher.active_dry_run_alerts == {'DryRunAlert'}
+    assert watcher.active_alerts == set()
+
+
+def test_process_result_mix_of_dry_run_and_real_alerts():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+
+    watcher.process_result([
+        _make_alert('RealAlert', 1500.0),
+        _make_alert('DryRunAlert', 1500.0, dry_run=True),
+    ])
+
+    individual_cb.assert_any_call('RealAlert', failing=True)
+    individual_cb.assert_any_call('DryRunAlert', failing=True, dry_run=True)
+    all_cb.assert_called_once_with(failing=True)
+    assert watcher.active_alerts == {'RealAlert'}
+    assert watcher.active_dry_run_alerts == {'DryRunAlert'}
+
+
+def test_process_result_dry_run_alert_resolved():
+    individual_cb = mock.Mock(spec=IndividualAlertCallback)
+    all_cb = mock.Mock(spec=AllAlertCallback)
+    watcher = _make_watcher(individual_alert_callback=individual_cb, all_alert_callback=all_cb)
+    watcher.active_dry_run_alerts = {'DryRunAlert'}
+
+    watcher.process_result([])
+
+    individual_cb.assert_called_once_with('DryRunAlert', failing=False, dry_run=True)
     all_cb.assert_not_called()


### PR DESCRIPTION
This is basically entirely label-driven: if an alert has the right
dry-run label, we'll special-case how we handle it and only notify in
Slack without truly transitioning the state machine (see the
corresponding PaaSTA PR).

I figured it'd be nice to be able for folks to be able to experiment
with alertmanager autorollbacks without having to commit to actually
using them (and potentially having longer deploys due to flakiness with
custom alerts or whatever)